### PR TITLE
Add embedded comments and discussion ids

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,13 @@ module.exports = {
   pathPrefix: '/',
   plugins: [
     {
+      resolve: `gatsby-plugin-ed-comments`,
+      options: {
+        commentsServerUrl: 'https://comments-for-yerevancoder-com.ed.community',
+        commentsScriptUrl: 'https://comments-for-yerevancoder-com.ed.community/-/ed-comments.v0.min.js'
+      }
+    },
+    {
       resolve: `gatsby-source-filesystem`,
       options: {
         path: `${__dirname}/src/pages`,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "gatsby": "^1.9.144",
     "gatsby-link": "^1.6.32",
+    "gatsby-plugin-ed-comments": "^0.4.2",
     "gatsby-plugin-feed": "^1.3.15",
     "gatsby-plugin-google-analytics": "^1.0.14",
     "gatsby-plugin-offline": "^1.0.12",

--- a/src/pages/2017-12-20-init-post/index.md
+++ b/src/pages/2017-12-20-init-post/index.md
@@ -4,6 +4,7 @@ tags: armenia, coding, javascript, jsconf
 author: Edgar Aroutiounian
 date: "2017-12-20"
 description: A strong first conference
+discussionId: "2017-12-20-first-conference"
 ---
 
 *By Edgar Aroutiounian*,

--- a/src/pages/2017-12-21-javascript-resources/index.md
+++ b/src/pages/2017-12-21-javascript-resources/index.md
@@ -4,6 +4,7 @@ tags: armenia, coding, javascript, jsconf, learning
 author: Edgar Aroutiounian
 date: "2017-12-21"
 description: some useful material for you 
+discussionId: "2017-12-21-useful-material"
 ---
 
 *By Edgar Aroutiounian*,

--- a/src/pages/2017-12-23-tech-places-and-events/index.md
+++ b/src/pages/2017-12-23-tech-places-and-events/index.md
@@ -4,6 +4,7 @@ tags: armenia, coding
 author: Edgar Aroutiounian
 date: "2017-12-23"
 description: Where to see things
+discussionId: "2017-12-23-tech-places-events"
 ---
 
 *By Edgar Aroutiounian*,

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 import get from 'lodash/get';
+import EffectiveDiscussionsCommentsIframe from 'gatsby-plugin-ed-comments'
 
 import Bio from '../components/Bio';
 import { rhythm, scale } from '../utils/typography';
@@ -30,6 +31,7 @@ class BlogPostTemplate extends React.Component {
           }}
         />
         <Bio />
+        <EffectiveDiscussionsCommentsIframe discussionId={post.frontmatter.discussionId} />
       </div>
     );
   }
@@ -51,6 +53,7 @@ export const pageQuery = graphql`
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
+        discussionId
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,6 +3835,12 @@ gatsby-module-loader@^1.0.9:
     babel-runtime "^6.26.0"
     loader-utils "^0.2.16"
 
+gatsby-plugin-ed-comments@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-ed-comments/-/gatsby-plugin-ed-comments-0.4.2.tgz#55a47edd9d6727c68e798d45670dc54e6a688286"
+  dependencies:
+    babel-runtime "^6.26.0"
+
 gatsby-plugin-feed@^1.3.15:
   version "1.3.15"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-feed/-/gatsby-plugin-feed-1.3.15.tgz#c691f5022a9ed92d7148f1f9594c115901d2de2a"


### PR DESCRIPTION
The discussion ids make the embedded comments system reuse the same discussion, even if one changes the URL to the blog post.

There's currently a bug if one starts on a blog post, then navigates to the index, and to another blog post: the embedded comments Gatsby plugin currently doesn't listen to the unmount & remount events that happen then, and doesn't recreate the embedded comments. So after having navigated via the index to another page, the comments won't appear. I'll start looking into fixing this later today or tomorrow. (This is because Gatsby uses history.push instead of loading new pages. Which is a good thing but I didn't think about that)