### PR TITLE
Upgr embedded comments plugin: bug fixes, makes navigation work

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "gatsby": "^1.9.144",
     "gatsby-link": "^1.6.32",
-    "gatsby-plugin-ed-comments": "^0.4.2",
+    "gatsby-plugin-ed-comments": "^0.4.4",
     "gatsby-plugin-feed": "^1.3.15",
     "gatsby-plugin-google-analytics": "^1.0.14",
     "gatsby-plugin-offline": "^1.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3854,9 +3854,9 @@ gatsby-module-loader@^1.0.9:
     babel-runtime "^6.26.0"
     loader-utils "^0.2.16"
 
-gatsby-plugin-ed-comments@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-ed-comments/-/gatsby-plugin-ed-comments-0.4.2.tgz#55a47edd9d6727c68e798d45670dc54e6a688286"
+gatsby-plugin-ed-comments@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-ed-comments/-/gatsby-plugin-ed-comments-0.4.4.tgz#250c9d00fcabc7e7d6f947fc31b55eb6cf141411"
   dependencies:
     babel-runtime "^6.26.0"
 


### PR DESCRIPTION
I think you'll need to do an empty-cache-and-reload page refresh in Chrome, so the latest version of the script will get loaded. Hmm I should bump the version number in the URL so won't be needed the next time.